### PR TITLE
Kafka message timestamps should be in milliseconds, not microseconds.

### DIFF
--- a/src/kafe_utils.erl
+++ b/src/kafe_utils.erl
@@ -21,8 +21,7 @@ broker_name(Host, Port) ->
   string:join([bucs:to_string(Host1), bucs:to_string(Port)], ":").
 
 timestamp() ->
-  {Mega, Sec, Micro} = erlang:timestamp(),
-  (Mega * 1000000 + Sec) * 1000000 + Micro.
+  erlang:system_time(millisecond).
 
 % Because meck can't mock gen_server:call/2
 gen_server_call(ServerRef, Request) ->


### PR DESCRIPTION
`kafe` was producing messages with timestamps in microseconds where Kafka expects milliseconds. Fun consequences:
- Kafka brokers will never delete old log segments, as they see timestamps in the far future 🤦‍♂️  ;
- Kafka brokers will roll out new log segments much more frequently than expected, as timestamps increase 1000 times faster than normal, causing brokers to create a ridiculous number of files and run out of file descriptors 😱 .